### PR TITLE
added check whether configuration is complete

### DIFF
--- a/app/code/community/Thebod/Shippingrates/Model/Carrier.php
+++ b/app/code/community/Thebod/Shippingrates/Model/Carrier.php
@@ -217,4 +217,14 @@ class Thebod_Shippingrates_Model_Carrier extends Mage_Shipping_Model_Carrier_Abs
         );
         return $allowedMethods;
     }
+
+    public function isActive()
+    {
+        $data = unserialize(base64_decode($this->getConfigData('shippingconfig')));
+
+        if (!$data) {
+            return false;
+        }
+        return parent::isActive();
+    }
 }


### PR DESCRIPTION
If no configuration is set, there is a warning and checkout breaks. This fixes it.
